### PR TITLE
Add lorebooks to wip.la zonefile

### DIFF
--- a/zones/wip.la.yaml
+++ b/zones/wip.la.yaml
@@ -33,3 +33,4 @@ balloon: [ns1.he.net, ns2.he.net, ns3.he.net, ns4.he.net, ns5.he.net] # Register
 blue: [ns1.afraid.org, ns2.afraid.org, ns3.afraid.org, ns4.afraid.org]
 latexbuddy: [ns1.desec.io, ns2.desec.org]
 wlf: [ns1.crystalcloud.xyz, ns2.crystalcloud.xyz]
+lorebooks: [glauca.whitelabels.recaptime.eu.org] # whitelabelled nameserver for HexDNS


### PR DESCRIPTION
## About this PR

We would like to setup `lorebooks.wip.la` not only as an shortcut to different docs/wikis in the future, but also host some of our docs under that subdomain in the future.

## Notes on nameservers

I configured HexDNS to use @RecapTime's whitelabelled nameserver pointing to HexDNS's IP addresses on Cloudflare, minus the proxy part.
