### PR TITLE
Add recaptime-dev.cluster.ws to cluser.ws zonefile

### DIFF
--- a/zones/cluster.ws.yaml
+++ b/zones/cluster.ws.yaml
@@ -54,3 +54,4 @@ melange-backend: [ns1.digitalocean.com, ns2.digitalocean.com, ns3.digitalocean.c
 bal: [ns31.cloudns.net, ns32.cloudns.net, ns33.cloudns.net, ns34.cloudns.net]
 her: [ns41.cloudns.net, ns42.cloudns.net, ns43.cloudns.net, ns44.cloudns.net] # register her cluster
 net: [ns1.vercel-dns.com, ns2.vercel-dns.com]
+recaptime-dev: [glauca.whitelabels.recaptime.eu.org, glauca2.whitelabels.recaptime.eu.org] # mostly for custom DNS in our own tailnet


### PR DESCRIPTION
Reason: For use as custom DNS records in @RecapTime's internal network via Tailscale

Same with `lorebooks.wip.la`, we use whitelabelled NS records for HexDNS on Glauca Digital.