### PR TITLE
Register lavalink.cluster.ws

### DIFF
--- a/zones/cluster.ws.yaml
+++ b/zones/cluster.ws.yaml
@@ -83,3 +83,5 @@ itbot: [ns1.desec.io, ns2.desec.org, ns1.gcorelabs.net, ns2.gcdn.services]
 easio: [ns41.cloudns.net, ns42.cloudns.net, ns43.cloudns.net, ns44.cloudns.net] # Register easio fmm18 id
 itdude: [ns1.afraid.org, ns2.afraid.org, ns1.gcorelabs.net, ns2.gcdn.services]
 chia: [ns41.cloudns.net, ns42.cloudns.net, ns43.cloudns.net, ns44.cloudns.net]
+lavalink: [ns1.gcorelabs.net, ns2.gcdn.services] # Register lavalink.cluster.ws
+


### PR DESCRIPTION
lavalink: [ns1.gcorelabs.net, ns2.gcdn.services] # Register lavalink.cluster.ws