### PR TITLE
Register tgp24.wip.la

### DIFF
--- a/zones/wip.la.yaml
+++ b/zones/wip.la.yaml
@@ -6,6 +6,7 @@
 #
 # Domains expire 1 year after the last modification
 # ---------------------------------------------------------------------------------------------------------------------
+tgp24: [chip.ns.cloudflare.com, emma.ns.cloudflare.com] #register tgp24.wip.la
 synima: [ns1.afraid.org, ns2.afraid.org, ns3.afraid.org, ns4.afraid.org]
 rurl: [galilea.ns.cloudflare.com, maciej.ns.cloudflare.com]
 tfj: [ns1.gcorelabs.net, ns2.gcdn.services] # Register tfj.wip.la


### PR DESCRIPTION
This is to register my subdomain, tgp24.wip.la
**Note - I was able to use cloudflare, as I have used the account for subdomains before and it worked, and the nameservers are the same. (I was able to use eu.org subdomains and it worked perfectly. So please accept this if it looks good.)**