### PR TITLE
Update cluster.ws.yaml to add "logging-server" subdomain

### DIFF
--- a/zones/cluster.ws.yaml
+++ b/zones/cluster.ws.yaml
@@ -240,3 +240,4 @@ secnet: [freedns1.registrar-servers.com, freedns2.registrar-servers.com, freedns
 secure: [freedns1.registrar-servers.com, freedns2.registrar-servers.com, freedns3.registrar-servers.com, freedns4.registrar-servers.com, freedns5.registrar-servers.com]
 frank-gcp: [ns-cloud-d1.googledomains.com, ns-cloud-d2.googledomains.com, ns-cloud-d3.googledomains.com, ns-cloud-d4.googledomains.com]
 munt: [ns1.afraid.org, ns2.afraid.org, ns3.afraid.org, ns4.afraid.org]
+logging-server: [ns1.p201.dns.oraclecloud.net, ns2.p201.dns.oraclecloud.net, ns3.p201.dns.oraclecloud.net,ns4.p201.dns.oraclecloud.net]


### PR DESCRIPTION
This adds the logging-server.cluster.ws domain (it's for logging to a discord server from a game I work on)