### PR TITLE
Update bal.cluster.ws & balloon.wip.la

### DIFF
--- a/zones/cluster.ws.yaml
+++ b/zones/cluster.ws.yaml
@@ -140,7 +140,7 @@ instaplot: [freedns1.registrar-servers.com, freedns2.registrar-servers.com, free
 public: [ns1.desec.io, ns2.desec.org]
 rony: [ns41.cloudns.net, ns42.cloudns.net, ns43.cloudns.net, ns44.cloudns.net]
 melange-backend: [ns1.digitalocean.com, ns2.digitalocean.com, ns3.digitalocean.com]
-bal: [ns31.cloudns.net, ns32.cloudns.net, ns33.cloudns.net, ns34.cloudns.net]
+bal: [ns1.ydns.io, ns2.ydns.io]
 her: [ns41.cloudns.net, ns42.cloudns.net, ns43.cloudns.net, ns44.cloudns.net] # register her cluster
 net: [ns1.vercel-dns.com, ns2.vercel-dns.com]
 recaptime-dev: [glauca.whitelabels.recaptime.eu.org, glauca2.whitelabels.recaptime.eu.org] # mostly for custom DNS in our own tailnet

--- a/zones/wip.la.yaml
+++ b/zones/wip.la.yaml
@@ -134,7 +134,7 @@ alpha: [ns41.cloudns.net, ns42.cloudns.net, ns43.cloudns.net, ns44.cloudns.net] 
 sanzz: [ns1.he.net, ns2.he.net, ns3.he.net, ns4.he.net, ns5.he.net]
 itransition-intern: [ns1.linode.com, ns2.linode.com, ns3.linode.com, ns4.linode.com, ns5.linode.com]
 quo: [ns41.cloudns.net, ns42.cloudns.net, ns43.cloudns.net, ns44.cloudns.net]
-balloon: [ns31.cloudns.net, ns32.cloudns.net, ns33.cloudns.net, ns34.cloudns.net]
+balloon: [ns1.ydns.io, ns2.ydns.io]
 blue: [ns1.afraid.org, ns2.afraid.org, ns3.afraid.org, ns4.afraid.org]
 wlf: [ns1.crystalcloud.xyz, ns2.crystalcloud.xyz]
 lorebooks: [glauca.whitelabels.recaptime.eu.org] # whitelabelled nameserver for HexDNS


### PR DESCRIPTION
It's a subdomain that I set up for a long time, and it's still in operation.
I want to change the nameservers to remove the restrictions that exist in ClouDNS.