### PR TITLE
Add appado.wip.la

### DIFF
--- a/zones/wip.la.yaml
+++ b/zones/wip.la.yaml
@@ -346,6 +346,8 @@ zzhsjksk: [NS1.AFRAID.ORG, NS2.AFRAID.ORG, NS3.AFRAID.ORG, NS4.AFRAID.ORG]
 uy-1: [ns1.desec.io, ns2.desec.org, ns1.desec.io, ns2.desec.org]
 connect: [ns1.desec.io, ns2.desec.org, ns1.desec.io, ns2.desec.org]
 higgs: [ns1.cloudns.net, ns2.cloudns.net, ns3.cloudns.net, ns4.cloudns.net]
+appado: [ns71.cloudns.net, ns72.cloudns.com, ns73.cloudns.net, ns74.cloudns.uk]
+
 is: [ns1.byet.org, ns2.byet.org, ns3.byet.org, ns4.byet.org, ns5.byet.org]
 survie: [NS1.AFRAID.ORG, NS2.AFRAID.ORG, NS3.AFRAID.ORG, NS4.AFRAID.ORG]
 nt: [ns1.digitalocean.com, ns2.digitalocean.com, ns3.digitalocean.com]


### PR DESCRIPTION
Register appado.wip.la using ClouDNS nameservers
